### PR TITLE
Updated UNet with tensorflow.keras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "3.6"
+  - "3.7"
+install:
+  - pip install tensorflow==1.13.1
+  - pip install Pillow==6.1.0
+  - pip install numpy==1.16.4
+  - pip install black==19.3b0
+  - pip install flake8==3.7.8
+  - pip install imgaug==0.2.9
+script:
+  - flake8 UNet/
+  - black UNet/ --check --diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ install:
   - pip install flake8==3.7.8
   - pip install imgaug==0.2.9
 script:
-  - flake8 UNet/
   - black UNet/ --check --diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,5 @@ language: python
 python:
   - "3.6"
   - "3.7"
-install:
-  - pip install tensorflow==1.13.1
-  - pip install Pillow==6.1.0
-  - pip install numpy==1.16.4
-  - pip install black==19.3b0
-  - pip install flake8==3.7.8
-  - pip install imgaug==0.2.9
 script:
   - black UNet/ --check --diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: python
-python:
-  - "3.6"
-  - "3.7"
-script:
-  - black UNet/ --check --diff

--- a/UNet/model.py
+++ b/UNet/model.py
@@ -10,7 +10,7 @@ class conv_set:
             inputs
         )
         y = tf.keras.layers.Conv2D(self.filters, kernel_size=3, activation="relu")(y)
-
+        y = tf.keras.layers.BatchNormalization()(y)
         return y
 
 

--- a/UNet/model.py
+++ b/UNet/model.py
@@ -7,10 +7,12 @@ class conv_set:
         self.filters = filters
 
     def __call__(self, inputs: tf.Tensor) -> tf.Tensor:
-        y = tf.keras.layers.Conv2D(self.filters, kernel_size=3, activation="relu")(
-            inputs
-        )
-        y = tf.keras.layers.Conv2D(self.filters, kernel_size=3, activation="relu")(y)
+        y = tf.keras.layers.Conv2D(
+            self.filters, kernel_size=3, padding="SAME", activation="relu"
+        )(inputs)
+        y = tf.keras.layers.Conv2D(
+            self.filters, kernel_size=3, padding="SAME", activation="relu"
+        )(y)
         y = tf.keras.layers.BatchNormalization()(y)
         return y
 
@@ -35,7 +37,7 @@ def UNet(args: "argparse.Namespace") -> tf.keras.Model:
     n_classes: int = args.n_classes
     decay: float = args.l2
 
-    x = tf.keras.Input(shape=(572, 572, 3))
+    x = tf.keras.Input(shape=(224, 224, 3))
 
     # down sampling
     conv1 = conv_set(64)(x)
@@ -49,13 +51,13 @@ def UNet(args: "argparse.Namespace") -> tf.keras.Model:
     conv5 = conv_set(1024)(max_pool4)
 
     # up sampling
-    concat1 = updampling(512, 4)([conv5, conv4])
+    concat1 = updampling(512)([conv5, conv4])
     conv6 = conv_set(512)(concat1)
-    concat2 = updampling(256, 16)([conv6, conv3])
+    concat2 = updampling(256)([conv6, conv3])
     conv7 = conv_set(256)(concat2)
-    concat3 = updampling(128, 40)([conv7, conv2])
+    concat3 = updampling(128)([conv7, conv2])
     conv8 = conv_set(128)(concat3)
-    concat4 = updampling(64, 88)([conv8, conv1])
+    concat4 = updampling(64)([conv8, conv1])
     conv9 = conv_set(64)(concat4)
 
     output = tf.keras.layers.Conv2D(filters=n_classes, kernel_size=1)(conv9)

--- a/UNet/model.py
+++ b/UNet/model.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import argparse
 import tensorflow as tf
 
 

--- a/UNet/model.py
+++ b/UNet/model.py
@@ -68,5 +68,4 @@ def UNet(args):
 
 
 if __name__ == "__main__":
-    unet = UNet()
-    print(unet.summary())
+    pass

--- a/UNet/model.py
+++ b/UNet/model.py
@@ -1,11 +1,12 @@
+from typing import Optional
 import tensorflow as tf
 
 
 class conv_set:
-    def __init__(self, filters):
+    def __init__(self, filters: int):
         self.filters = filters
 
-    def __call__(self, inputs):
+    def __call__(self, inputs: tf.Tensor) -> tf.Tensor:
         y = tf.keras.layers.Conv2D(self.filters, kernel_size=3, activation="relu")(
             inputs
         )
@@ -15,11 +16,11 @@ class conv_set:
 
 
 class updampling:
-    def __init__(self, filters, cut):
+    def __init__(self, filters: int, cut: Optional[int] = 0):
         self.filters = filters
         self.cut = cut
 
-    def __call__(self, inputs):
+    def __call__(self, inputs: tf.Tensor) -> tf.Tensor:
         upconv = tf.keras.layers.Conv2DTranspose(
             self.filters, kernel_size=2, strides=2
         )(inputs[0])
@@ -30,9 +31,9 @@ class updampling:
         return concat
 
 
-def UNet(args):
-    n_classes = args.n_classes
-    decay = args.l2
+def UNet(args: "argparse.Namespace") -> tf.keras.Model:
+    n_classes: int = args.n_classes
+    decay: float = args.l2
 
     x = tf.keras.Input(shape=(572, 572, 3))
 

--- a/UNet/prepare_data.py
+++ b/UNet/prepare_data.py
@@ -1,4 +1,3 @@
-import imgaug as iaa
 import numpy as np
 import os
 from PIL import Image

--- a/UNet/prepare_data.py
+++ b/UNet/prepare_data.py
@@ -18,12 +18,12 @@ def data_gen(
             segs = []
             for img_file in b:
                 img = Image.open(train_data + img_file).convert("RGB")
-                img = img.resize((572, 572))
+                img = img.resize((224, 224))
                 img = np.asarray(img) / 255.0
                 imgs.append(img)
 
                 seg = Image.open(seg_data + img_file.split(".")[0] + "-seg.png")
-                seg = seg.resize((388, 388))
+                seg = seg.resize((224, 224))
                 seg = np.asarray(seg)
                 seg = identity[seg]
                 segs.append(seg)

--- a/UNet/prepare_data.py
+++ b/UNet/prepare_data.py
@@ -4,7 +4,9 @@ import os
 from PIL import Image
 
 
-def data_gen(train_data, seg_data, batch_size):
+def data_gen(
+    train_data: str, seg_data: str, batch_size: int
+) -> (np.ndarray, np.ndarray):
     inputs = np.array(os.listdir(train_data))
     batch = len(inputs) // batch_size
     identity = np.identity(2, dtype=np.int16)

--- a/UNet/train.py
+++ b/UNet/train.py
@@ -42,5 +42,4 @@ if __name__ == "__main__":
     tf.keras.backend.set_session(tf.Session(config=config))
 
     args = get_parser().parse_args()
-    # train(args)
-    print(type(args))
+    train(args)

--- a/UNet/train.py
+++ b/UNet/train.py
@@ -1,12 +1,13 @@
 import argparse
 import tensorflow as tf
 import model
+from prepare_data import data_gen
 
 
 def get_parser():
     """
-  Set hyper parameters for training UNet.
-  """
+    Set hyper parameters for training UNet.
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("--n_classes", type=int, default=2)
     parser.add_argument("--epoch", type=int, default=100)
@@ -26,12 +27,19 @@ def train(args):
     unet = model.UNet(args)
     unet.compile(
         optimizer=tf.keras.optimizers.Adam(lr),
-        loss="categorical_crossentropy",
+        loss="binary_crossentropy",
         metrics=["accuracy"],
     )
     unet.summary()
 
+    generator = data_gen("./dataset/raw_images/", "./dataset/segmented_images/", 4)
+    unet.fit_generator(generator, steps_per_epoch=30, epochs=100)
+
 
 if __name__ == "__main__":
+    config = tf.ConfigProto()
+    config.gpu_options.allow_growth = True
+    tf.keras.backend.set_session(tf.Session(config=config))
+
     args = get_parser().parse_args()
     train(args)

--- a/UNet/train.py
+++ b/UNet/train.py
@@ -21,8 +21,8 @@ def get_parser():
     return parser
 
 
-def train(args):
-    lr = args.learning_rate
+def train(args: "argparse.Namespace"):
+    lr: float = args.learning_rate
 
     unet = model.UNet(args)
     unet.compile(
@@ -42,4 +42,5 @@ if __name__ == "__main__":
     tf.keras.backend.set_session(tf.Session(config=config))
 
     args = get_parser().parse_args()
-    train(args)
+    # train(args)
+    print(type(args))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-tensorflow
-Pillow
-imgaug
-numpy
-scipy
-matplotlib
+tensorflow==1.13.1
+Pillow==6.1.0
+imgageaug==0.2.9
+numpy==1.16.4
+scipy==1.3.0
+matplotlib==3.1.1
+black==19.3b0


### PR DESCRIPTION
## Purpose
Tensorflow does not support `tf.placeholder` in Tensorflow 2.0, and change to tf.keras.

## Changes
- Rewrite the model with tf.keras
- the model is `tf.keras.Model`
