### PR TITLE
Change UNet for running on TF2.0

### DIFF
--- a/UNet/prepare_data.py
+++ b/UNet/prepare_data.py
@@ -28,7 +28,7 @@ def data_gen(
                         iaa.ChannelShuffle(p=1.0),
                     ]
                 )
-                img = seq.augment_images(img)
+                img = seq.augment_image(img)
                 img = img / 255.0
                 imgs.append(img)
 
@@ -37,7 +37,7 @@ def data_gen(
                 )
                 seg = seg.resize((224, 224))
                 seg = np.asarray(seg)
-                seg = identity[seg]
+                seg = identity[seg].astype(np.float32)
                 segs.append(seg)
 
             yield np.array(imgs), np.array(segs)

--- a/UNet/train.py
+++ b/UNet/train.py
@@ -66,9 +66,15 @@ def train(args: "argparse.Namespace"):
 
 
 if __name__ == "__main__":
-    config = tf.ConfigProto()
-    config.gpu_options.allow_growth = True
-    tf.keras.backend.set_session(tf.Session(config=config))
+    if tf.__version__ >= "2.0.0":
+        device = tf.config.experimental.list_physical_devices("GPU")
+        if len(device) > 0:
+            for dev in device:
+                tf.config.experimental.set_memory_growth(dev, True)
+    else:
+        config = tf.ConfigProto()
+        config.gpu_options.allow_growth = True
+        tf.keras.backend.set_session(tf.Session(config=config))
 
     args = get_parser().parse_args()
     train(args)


### PR DESCRIPTION
For GPU environment, I add codes for `set_memory_growth` that can be used in TF2.0. And I fixed a bug. In preparing data, I used np.float32 for input images but np.int16 for segmentation images, so I integrated to np.float32.